### PR TITLE
Added Tooltip Visibility Control

### DIFF
--- a/src/main/java/dev/overgrown/aspectslib/AspectsLibClient.java
+++ b/src/main/java/dev/overgrown/aspectslib/AspectsLibClient.java
@@ -1,5 +1,6 @@
 package dev.overgrown.aspectslib;
 
+import dev.overgrown.aspectslib.client.AspectsTooltipConfig;
 import dev.overgrown.aspectslib.client.tooltip.AspectTooltipComponent;
 import dev.overgrown.aspectslib.client.tooltip.AspectTooltipData;
 import dev.overgrown.aspectslib.data.*;
@@ -40,6 +41,9 @@ public class AspectsLibClient implements ClientModInitializer {
 
     @Override
     public void onInitializeClient() {
+        // Initialize default tooltip visibility to hidden
+        AspectsTooltipConfig.setAlwaysShow(false);
+
         EntityRendererRegistry.register(ModEntities.AURA_NODE, AuraNodeRenderer::new);
 
         // Register custom tooltip component

--- a/src/main/java/dev/overgrown/aspectslib/client/AspectsTooltipConfig.java
+++ b/src/main/java/dev/overgrown/aspectslib/client/AspectsTooltipConfig.java
@@ -1,0 +1,31 @@
+package dev.overgrown.aspectslib.client;
+
+import net.minecraft.entity.player.PlayerEntity;
+import net.minecraft.item.ItemStack;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.function.BiPredicate;
+
+public class AspectsTooltipConfig {
+    private static final List<BiPredicate<ItemStack, PlayerEntity>> visibilityConditions = new ArrayList<>();
+    private static boolean alwaysShow = false;
+
+    static {
+        // Default condition: never show unless conditions are added.
+        visibilityConditions.add((stack, player) -> alwaysShow);
+    }
+
+    public static void addVisibilityCondition(BiPredicate<ItemStack, PlayerEntity> condition) {
+        visibilityConditions.add(condition);
+    }
+
+    public static void setAlwaysShow(boolean alwaysShow) {
+        AspectsTooltipConfig.alwaysShow = alwaysShow;
+    }
+
+    public static boolean shouldShowTooltip(ItemStack stack, @Nullable PlayerEntity player) {
+        return visibilityConditions.stream().anyMatch(condition -> condition.test(stack, player));
+    }
+}

--- a/src/main/java/dev/overgrown/aspectslib/mixin/client/ItemStackClientMixin.java
+++ b/src/main/java/dev/overgrown/aspectslib/mixin/client/ItemStackClientMixin.java
@@ -1,12 +1,15 @@
 package dev.overgrown.aspectslib.mixin.client;
 
 import dev.overgrown.aspectslib.api.IAspectDataProvider;
+import dev.overgrown.aspectslib.client.AspectsTooltipConfig;
 import dev.overgrown.aspectslib.client.tooltip.AspectTooltipComponent;
 import dev.overgrown.aspectslib.client.tooltip.AspectTooltipData;
 import dev.overgrown.aspectslib.data.AspectData;
 import net.fabricmc.api.EnvType;
 import net.fabricmc.api.Environment;
+import net.minecraft.client.MinecraftClient;
 import net.minecraft.client.item.TooltipData;
+import net.minecraft.entity.player.PlayerEntity;
 import net.minecraft.item.ItemStack;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
@@ -37,6 +40,14 @@ public abstract class ItemStackClientMixin {
         AspectData aspectData = provider.aspectslib$getAspectData();
 
         if (aspectData == null || aspectData.isEmpty()) {
+            return;
+        }
+
+        // Check if we should show aspects based on conditions
+        MinecraftClient client = MinecraftClient.getInstance();
+        PlayerEntity player = client.player;
+
+        if (!AspectsTooltipConfig.shouldShowTooltip((ItemStack)(Object)this, player)) {
             return;
         }
 


### PR DESCRIPTION
Made changes to hide aspects in tooltips by default while allowing developers to customize when they're shown.

### Key Changes:
1. **Hidden by default**: Aspects won't show in tooltips unless explicitly enabled
2. **Flexible conditions**: Developers can add multiple visibility conditions
3. **Player context**: Conditions have access to player state and inventory
4. **Easy to use**: Simple API for adding custom conditions
5. **Non-intrusive**: Doesn't require changes to existing item/entity code

### Usage Examples:
1. **Always show aspects**:
```java
AspectsTooltipConfig.setAlwaysShow(true);
```

2. **Show only when holding a specific item**:
```java
AspectsTooltipConfig.addVisibilityCondition((stack, player) -> {
    if (player == null) return false;
    return player.getMainHandStack().isOf(Items.GOLD_INGOT);
});
```

3. **Show only in creative mode**:
```java
AspectsTooltipConfig.addVisibilityCondition((stack, player) -> {
    return player != null && player.isCreative();
});
```

4. **Show only when sneaking**:
```java
AspectsTooltipConfig.addVisibilityCondition((stack, player) -> {
    return player != null && player.isSneaking();
});
```

5. **Complex condition (show when holding compass and in overworld)**:
```java
AspectsTooltipConfig.addVisibilityCondition((stack, player) -> {
    if (player == null) return false;
    return player.getMainHandStack().isOf(Items.COMPASS) && 
           player.getWorld().getRegistryKey() == World.OVERWORLD;
});
```