### PR TITLE
Conditional Transparency for Aura Nodes

### DIFF
--- a/src/main/java/dev/overgrown/aspectslib/api/AspectsAPI.java
+++ b/src/main/java/dev/overgrown/aspectslib/api/AspectsAPI.java
@@ -1,7 +1,9 @@
 package dev.overgrown.aspectslib.api;
 
 import dev.overgrown.aspectslib.data.*;
+import dev.overgrown.aspectslib.entity.aura_node.client.AuraNodeVisibilityConfig;
 import it.unimi.dsi.fastutil.objects.Object2IntOpenHashMap;
+import net.minecraft.entity.player.PlayerEntity;
 import net.minecraft.item.Item;
 import net.minecraft.item.ItemStack;
 import net.minecraft.registry.Registries;
@@ -9,6 +11,7 @@ import net.minecraft.util.Identifier;
 import org.jetbrains.annotations.Nullable;
 
 import java.util.Optional;
+import java.util.function.BiPredicate;
 
 /**
  * Public API for AspectsLib functionality.
@@ -157,5 +160,21 @@ public class AspectsAPI {
      */
     public static java.util.Map<Identifier, Aspect> getAllAspects() {
         return java.util.Collections.unmodifiableMap(ModRegistries.ASPECTS);
+    }
+
+    /**
+     * Adds a condition for when aura nodes should be fully visible.
+     * @param condition A predicate that takes a PlayerEntity and boolean indicating if the node has aspects
+     */
+    public static void addAuraNodeVisibilityCondition(BiPredicate<PlayerEntity, Boolean> condition) {
+        AuraNodeVisibilityConfig.addVisibilityCondition(condition);
+    }
+
+    /**
+     * Sets whether aura nodes should always be fully visible.
+     * @param alwaysShow true to always show nodes, false to use conditions
+     */
+    public static void setAuraNodesAlwaysVisible(boolean alwaysShow) {
+        AuraNodeVisibilityConfig.setAlwaysShow(alwaysShow);
     }
 }

--- a/src/main/java/dev/overgrown/aspectslib/entity/aura_node/client/AuraNodeVisibilityConfig.java
+++ b/src/main/java/dev/overgrown/aspectslib/entity/aura_node/client/AuraNodeVisibilityConfig.java
@@ -1,0 +1,31 @@
+package dev.overgrown.aspectslib.entity.aura_node.client;
+
+import net.minecraft.entity.player.PlayerEntity;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.function.BiPredicate;
+
+public class AuraNodeVisibilityConfig {
+    private static final List<BiPredicate<PlayerEntity, Boolean>> visibilityConditions = new ArrayList<>();
+    private static boolean alwaysShow = false;
+
+    static {
+        // Default condition: never show unless conditions are added
+        visibilityConditions.add((player, hasAspects) -> alwaysShow);
+    }
+
+    public static void addVisibilityCondition(BiPredicate<PlayerEntity, Boolean> condition) {
+        visibilityConditions.add(condition);
+    }
+
+    public static void setAlwaysShow(boolean alwaysShow) {
+        AuraNodeVisibilityConfig.alwaysShow = alwaysShow;
+    }
+
+    public static boolean shouldShowNode(@Nullable PlayerEntity player, boolean hasAspects) {
+        if (player == null) return false;
+        return visibilityConditions.stream().anyMatch(condition -> condition.test(player, hasAspects));
+    }
+}

--- a/src/main/java/dev/overgrown/aspectslib/entity/aura_node/render/AuraNodeRenderer.java
+++ b/src/main/java/dev/overgrown/aspectslib/entity/aura_node/render/AuraNodeRenderer.java
@@ -1,6 +1,7 @@
 package dev.overgrown.aspectslib.entity.aura_node.render;
 
 import dev.overgrown.aspectslib.AspectsLib;
+import dev.overgrown.aspectslib.entity.aura_node.client.AuraNodeVisibilityConfig;
 import dev.overgrown.aspectslib.entity.aura_node.AuraNodeEntity;
 import net.minecraft.client.MinecraftClient;
 import net.minecraft.client.render.*;
@@ -8,14 +9,14 @@ import net.minecraft.client.render.entity.EntityRenderer;
 import net.minecraft.client.render.entity.EntityRendererFactory;
 import net.minecraft.client.util.math.MatrixStack;
 import net.minecraft.util.Identifier;
-import net.minecraft.util.math.RotationAxis;
 import org.joml.Matrix3f;
 import org.joml.Matrix4f;
-import org.joml.Vector3f;
 
 public class AuraNodeRenderer extends EntityRenderer<AuraNodeEntity> {
 
     private static final float SCALE = 1.0F;
+    private static final float DEFAULT_ALPHA = 0.2f; // 20% opacity by default
+    private static final float VISIBLE_ALPHA = 1.0f; // 100% opacity when visible
 
     public AuraNodeRenderer(EntityRendererFactory.Context ctx) {
         super(ctx);
@@ -36,24 +37,39 @@ public class AuraNodeRenderer extends EntityRenderer<AuraNodeEntity> {
         MinecraftClient mc = MinecraftClient.getInstance();
         Camera camera = mc.gameRenderer.getCamera();
 
+        // Check if it should show the node with full clarity
+        boolean shouldShow = AuraNodeVisibilityConfig.shouldShowNode(mc.player, !node.getAspects().isEmpty());
+
+        // Calculate alpha based on visibility condition
+        float alpha = shouldShow ? VISIBLE_ALPHA : DEFAULT_ALPHA;
+
+        // Don't render if completely transparent
+        if (alpha <= 0.0f) {
+            return;
+        }
+
         pose.push();
         pose.multiply(camera.getRotation());
 
         VertexConsumer buffer = bufferSource.getBuffer(RenderLayer.getEntityTranslucent(getTexture(node)));
 
         int argb = node.getRenderColour();
-        int alpha = (argb >> 24) & 0xFF;
+        int baseAlpha = (argb >> 24) & 0xFF;
         int red = (argb >> 16) & 0xFF;
         int green = (argb >> 8) & 0xFF;
         int blue = argb & 0xFF;
 
+        // Apply calculated alpha to the base color
+        int finalAlpha = (int)(baseAlpha * alpha);
+        if (finalAlpha <= 0) return; // Don't render if completely transparent
+
         Matrix4f pm = pose.peek().getPositionMatrix();
         Matrix3f nm = pose.peek().getNormalMatrix();
 
-        vertex(buffer, pm, nm, 0.0F, 0, 0, 1, red, green, blue, alpha);
-        vertex(buffer, pm, nm, 1.0F, 0, 1, 1, red, green, blue, alpha);
-        vertex(buffer, pm, nm, 1.0F, 1, 1, 0, red, green, blue, alpha);
-        vertex(buffer, pm, nm, 0.0F, 1, 0, 0, red, green, blue, alpha);
+        vertex(buffer, pm, nm, 0.0F, 0, 0, 1, red, green, blue, finalAlpha);
+        vertex(buffer, pm, nm, 1.0F, 0, 1, 1, red, green, blue, finalAlpha);
+        vertex(buffer, pm, nm, 1.0F, 1, 1, 0, red, green, blue, finalAlpha);
+        vertex(buffer, pm, nm, 0.0F, 1, 0, 0, red, green, blue, finalAlpha);
 
         pose.pop();
     }
@@ -67,5 +83,4 @@ public class AuraNodeRenderer extends EntityRenderer<AuraNodeEntity> {
                 .normal(normalMatrix, 0.0F, 1.0F, 0.0F)
                 .next();
     }
-
 }


### PR DESCRIPTION
Gave Aura Nodes conditional transparency based on a condition similar to how aspects are shown on tooltips. I modifed the rendering code to make it transparent by default and only show fully when a condition is met.

## Summary of Changes

1. **Created `AuraNodeVisibilityConfig`**: A configuration system similar to the tooltip system that manages when aura nodes should be visible.

2. **Modified `AuraNodeRenderer`**: 
   - Added conditional alpha transparency (20% by default, 100% when conditions are met)
   - Checks visibility conditions before rendering
   - Skips rendering if completely transparent

3. **Updated `AspectsLibClient`**: 
   - Added default visibility condition (show when holding Shift, similar to tooltips)
   - Initialized the visibility config

4. **Extended `AspectsAPI`**: Added methods for other mods to customize aura node visibility

## Default Behavior

- **By default**: Aura nodes are semi-transparent (20% opacity) and barely visible
- **When condition is met**: Aura nodes render at full opacity (100%)
- **Default condition**: Show fully when the player is holding Shift (mimicking tooltip behavior)

## Customization

Other mods can add their own conditions using the API:

```java
AspectsAPI.addAuraNodeVisibilityCondition((player, hasAspects) -> {
    // Custom condition - e.g., show when player has a specific item
    return player.getMainHandStack().isOf(Items.SPECTRAL_ARROW);
});
```

The system is flexible and allows multiple conditions - if any condition returns true, the node will be fully visible.