### PR TITLE
Finalized Aura Node visiblity condition

### DIFF
--- a/src/main/java/dev/overgrown/aspectslib/AspectsLibClient.java
+++ b/src/main/java/dev/overgrown/aspectslib/AspectsLibClient.java
@@ -12,8 +12,6 @@ import net.fabricmc.api.ClientModInitializer;
 import net.fabricmc.fabric.api.client.networking.v1.ClientPlayNetworking;
 import net.fabricmc.fabric.api.client.rendering.v1.EntityRendererRegistry;
 import net.fabricmc.fabric.api.client.rendering.v1.TooltipComponentCallback;
-import net.minecraft.client.MinecraftClient;
-import net.minecraft.client.gui.screen.Screen;
 import net.minecraft.util.Identifier;
 
 import java.util.HashMap;
@@ -47,7 +45,8 @@ public class AspectsLibClient implements ClientModInitializer {
         // Initialize default tooltip visibility to hidden
         AspectsTooltipConfig.setAlwaysShow(false);
 
-        // Initialize default aura node visibility to hidden
+        // Initialize aura node visibility to hidden by default
+        // No conditions are set by default - other mods must add them via API
         AuraNodeVisibilityConfig.setAlwaysShow(false);
 
         EntityRendererRegistry.register(ModEntities.AURA_NODE, AuraNodeRenderer::new);
@@ -58,13 +57,6 @@ public class AspectsLibClient implements ClientModInitializer {
                 return new AspectTooltipComponent(aspectTooltipData);
             }
             return null;
-        });
-
-        // Add default visibility condition for aura nodes (same as tooltip - show when holding Shift)
-        AuraNodeVisibilityConfig.addVisibilityCondition((player, hasAspects) -> {
-            if (!hasAspects) return false;
-            MinecraftClient client = MinecraftClient.getInstance();
-            return client.currentScreen != null && Screen.hasShiftDown();
         });
 
         // Handle aspect data sync from server

--- a/src/main/java/dev/overgrown/aspectslib/entity/aura_node/client/AuraNodeVisibilityConfig.java
+++ b/src/main/java/dev/overgrown/aspectslib/entity/aura_node/client/AuraNodeVisibilityConfig.java
@@ -11,11 +11,6 @@ public class AuraNodeVisibilityConfig {
     private static final List<BiPredicate<PlayerEntity, Boolean>> visibilityConditions = new ArrayList<>();
     private static boolean alwaysShow = false;
 
-    static {
-        // Default condition: never show unless conditions are added
-        visibilityConditions.add((player, hasAspects) -> alwaysShow);
-    }
-
     public static void addVisibilityCondition(BiPredicate<PlayerEntity, Boolean> condition) {
         visibilityConditions.add(condition);
     }
@@ -26,6 +21,14 @@ public class AuraNodeVisibilityConfig {
 
     public static boolean shouldShowNode(@Nullable PlayerEntity player, boolean hasAspects) {
         if (player == null) return false;
+
+        // If alwaysShow is true, show regardless of conditions
+        if (alwaysShow) return true;
+
+        // If no conditions are set, use default behavior (low transparency)
+        if (visibilityConditions.isEmpty()) return false;
+
+        // Check if any condition matches
         return visibilityConditions.stream().anyMatch(condition -> condition.test(player, hasAspects));
     }
 }


### PR DESCRIPTION
The Aura Node visibility should be completely configurable by other mods using the API now, with no default condition. The `AuraNodeRenderer` and `AspectsAPI` remain the same but I've made other changes:

1. **Removed all default conditions** from `AuraNodeVisibilityConfig`
2. **No automatic Shift-key behavior** - that was for testing but now the library doesn't impose any default visibility logic
3. **Pure API-driven system** - other mods must explicitly add their own conditions

## Usage Example for Other Mods

Other mods using your library would need to add their own visibility conditions:

```java
// In another mod's client initialization
AspectsAPI.addAuraNodeVisibilityCondition((player, hasAspects) -> {
    // Example: Show nodes when player has a specific item
    return player.getMainHandStack().isOf(Items.NETHER_STAR);
});

// Or example: Show nodes when player is in creative mode
AspectsAPI.addAuraNodeVisibilityCondition((player, hasAspects) -> {
    return player.isCreative();
});

// Or example: Show nodes when player has a specific effect
AspectsAPI.addAuraNodeVisibilityCondition((player, hasAspects) -> {
    return player.hasStatusEffect(StatusEffects.NIGHT_VISION);
});
```

## Default Behavior Now

- **By default**: Aura nodes are semi-transparent (20% opacity) because no conditions are met
- **When conditions are added via API**: Nodes become fully visible (100% opacity) when any condition returns true
- **Completely pluggable**: No built-in logic - entirely driven by API consumers

This makes the library modular and allows each mod that uses it to define its own conditions for when Aura Nodes should be visible.