### PR TITLE
Fix null Pointer Exeption in AetherChunkData

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -13,7 +13,7 @@ loader_version=0.17.3
 loom_version=1.11-SNAPSHOT
 
 # Mod Properties
-mod_version=1.1.7
+mod_version=1.1.8
 maven_group=dev.overgrown.aspectslib
 archives_base_name=aspectslib
 

--- a/src/main/java/dev/overgrown/aspectslib/aether/AetherChunkData.java
+++ b/src/main/java/dev/overgrown/aspectslib/aether/AetherChunkData.java
@@ -11,6 +11,7 @@ import net.minecraft.util.math.BlockPos;
 import net.minecraft.util.math.ChunkPos;
 import net.minecraft.world.World;
 import net.minecraft.world.biome.Biome;
+import org.jetbrains.annotations.NotNull;
 
 import java.util.Collections;
 import java.util.HashMap;
@@ -20,7 +21,7 @@ import java.util.Set;
 import static dev.overgrown.aspectslib.corruption.CorruptionManager.VITIUM_ID;
 
 public class AetherChunkData {
-    private final World world;
+    private World world;
     private final ChunkPos chunkPos;
     private final Map<Identifier, Integer> currentAether;
     private final Map<Identifier, Integer> maxAether;
@@ -52,6 +53,10 @@ public class AetherChunkData {
         this.totalExpendedThisHour = totalExpendedThisHour;
         this.hourStartTime = hourStartTime;
         this.initialized = true;
+    }
+
+    protected void setWorld(@NotNull World world) {
+        this.world = world;
     }
 
     private void initializeFromBiome() {
@@ -306,7 +311,8 @@ public class AetherChunkData {
         }
 
         return new AetherChunkData(
-                null, // World will be set when needed
+                // World ist set separately when the first chunk data is requested from AetherWorldState
+                null,
                 new ChunkPos(0, 0), // Position will be set by caller
                 currentAether,
                 maxAether,

--- a/src/main/java/dev/overgrown/aspectslib/aether/AetherWorldState.java
+++ b/src/main/java/dev/overgrown/aspectslib/aether/AetherWorldState.java
@@ -6,6 +6,7 @@ import net.minecraft.nbt.NbtList;
 import net.minecraft.util.math.ChunkPos;
 import net.minecraft.world.PersistentState;
 import net.minecraft.world.World;
+import org.jetbrains.annotations.NotNull;
 
 import java.util.Collection;
 import java.util.HashMap;
@@ -21,7 +22,13 @@ public class AetherWorldState extends PersistentState {
     }
 
     public AetherChunkData getOrCreateChunkData(ChunkPos chunkPos, World world) {
-        this.world = world;
+        // Ensure that on first request of a chunk, the world reference is set for all chunks loaded from disk
+        if (this.world == null) {
+            this.world = world;
+            for (AetherChunkData aetherChunkData : chunkData.values()) {
+                aetherChunkData.setWorld(this.world);
+            }
+        }
         return chunkData.computeIfAbsent(chunkPos, pos -> {
             AetherChunkData data = new AetherChunkData(world, pos);
             markDirty();


### PR DESCRIPTION
Currently if AetherChunkData is loaded from disk, the final world variable is set to null.
If the world is loaded from disk and a particular chunk was saved and becomes corrupted this can cause a Null Pointer Exception:
`java.lang.NullPointerException: Cannot invoke "net.minecraft.world.World.isClient()" because "world" is null
	at knot//dev.overgrown.aspectslib.aether.AetherManager.isDeadZone(AetherManager.java:79)
	at knot//dev.overgrown.aspectslib.aether.AetherChunkData.canHarvest(AetherChunkData.java:98)
	at knot//dev.overgrown.aspectslib.aether.AetherChunkData.harvestAether(AetherChunkData.java:107)
	at knot//dev.overgrown.aspectslib.corruption.CorruptionManager.processAetherConsumption(CorruptionManager.java:306)
	at knot//dev.overgrown.aspectslib.corruption.CorruptionManager.processRegionCorruption(CorruptionManager.java:138)
	at knot//dev.overgrown.aspectslib.corruption.CorruptionManager.processWorldCorruption(CorruptionManager.java:86)
	at knot//dev.overgrown.aspectslib.corruption.CorruptionManager.onServerTick(CorruptionManager.java:52)`

This PR fixes the problem by having AetherWorldState set the world variable of all its loaded AetherChunkData objects on the first call to get any AetherChunkData.
